### PR TITLE
Record `remoteAddress` in unmapped mapper

### DIFF
--- a/src/mappers/unmapped.js
+++ b/src/mappers/unmapped.js
@@ -31,12 +31,13 @@ module.exports = {
     type: 'json'
 };
 
-function map (data, referer, userAgent) {
+function map (data, referer, userAgent, remoteAddress) {
     return JSON.stringify({
         data: data,
         referer: referer,
         userAgent: userAgent,
-        browser: getBrowser(userAgent)
+        browser: getBrowser(userAgent),
+        remoteAddress: remoteAddress
     });
 }
 

--- a/test/mappers/unmapped.js
+++ b/test/mappers/unmapped.js
@@ -132,17 +132,18 @@ suite('mappers/unmapped:', function () {
             });
 
             suite('call mapper:', function () {
-                var data, referer, userAgent, result;
+                var data, referer, userAgent, remoteAddress, result;
 
                 setup(function () {
                     data = {};
                     referer = {};
                     userAgent = {};
-                    result = mapper(data, referer, userAgent);
+                    remoteAddress = {};
+                    result = mapper(data, referer, userAgent, remoteAddress);
                 });
 
                 teardown(function () {
-                    data = referer = userAgent = result = undefined;
+                    data = referer = userAgent = remoteAddress = result = undefined;
                 });
 
                 test('useragent.lookup was called once', function () {
@@ -160,7 +161,8 @@ suite('mappers/unmapped:', function () {
                 });
 
                 test('result was correct', function () {
-                    assert.strictEqual(result, '{"data":{},"referer":{},"userAgent":{},"browser":{"name":{},"version":{}}}');
+                    assert.strictEqual(result,
+                        '{"data":{},"referer":{},"userAgent":{},"browser":{"name":{},"version":{}},"remoteAddress":{}}');
                 });
             });
         });


### PR DESCRIPTION
In my use case, remoteAddress helps a lot when analyzing beacons. It seems this argument is passed into map function but it's never used yet: https://github.com/springernature/boomcatch/blob/master/src/index.js#L656

I'm adding it to **unmapped** mapper.

